### PR TITLE
bugfix/transfer decimals

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                     </p>
                 </div>
                 <div id='reset'>
-                    <a href='javascript:void(0)' onclick={window.location.reload()}>Start again</a>
+                    <a href='javascript:void(0)' onclick={window.locatio§n.reload()}>Start again</a>
                 </div>
             </div>
         </section>
@@ -188,6 +188,9 @@
                             </p>
                             <p>
                                 <input autocapitalize="off" class="field long-field" type='text' name='target_address' id='target_address' placeholder='Target address' />
+                            </p>
+                            <p>
+                                <input autocapitalize="off" class="field short-field" type='text' name='decimals' id='decimals' placeholder='Decimals (default 18)' />
                             </p>
                             <p>
                                 <input autocapitalize="off" class="field short-field" type='text' name='chain_id' id='chain_id' placeholder='Chain id (optional)' />

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                     </p>
                 </div>
                 <div id='reset'>
-                    <a href='javascript:void(0)' onclick={window.locatio§n.reload()}>Start again</a>
+                    <a href='javascript:void(0)' onclick={window.location.reload()}>Start again</a>
                 </div>
             </div>
         </section>

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -64,7 +64,12 @@ window.generatePaymentUrl = function() {
 		document.getElementById("function_name").value !== ""
 			? document.getElementById("function_name").value
 			: null;
+	const decimals =
+		document.getElementById("decimals").value !== ""
+			? document.getElementById("decimals").value
+			: 18;
 	let params = {};
+
 	paramFields.forEach(ts => {
 		const key = document.getElementById(`key_${ts}`).value;
 		let val = document.getElementById(`val_${ts}`).value;
@@ -73,7 +78,17 @@ window.generatePaymentUrl = function() {
 				val += "e18";
 			}
 		}
+		console.log('key key', key, key === "uint256", function_name)
+		if (key === "uint256") {
+			console.log('in val', val)
+			if (val !== "") {
+				val += `e${decimals}`;
+				console.log('in valval', val)
+			}
+		}
+		console.log('after', val)
 		if (val !== "") {
+			console.log('if (val !== "") {', val, key, decimals)
 			params[key] = val;
 		}
 	});
@@ -84,6 +99,8 @@ window.generatePaymentUrl = function() {
 	}
     
 	try {
+        console.log('params', params);
+
          const data = {
 			scheme: url_scheme,
 			prefix,
@@ -133,13 +150,13 @@ window.showView = function(name) {
 	} else if(name === 'payment-channel-request'){
 		document.getElementById("payment-channel-request-form").style.display = "block";
 		document.getElementById("reset").style.display = "block";
-
-	}else if (name === "ether") {
+	} else if (name === "ether") {
 		document.getElementById("payment-request").style.display = "none";
 		document.getElementById("payment-request-form").style.display = "block";
 		
 		document.getElementById("function_name").style.display = "none";
 		document.getElementById("add_parameter").style.visibility = "hidden";
+		document.getElementById("decimals").style.display = "none";
 		addNewParam();
 		document.getElementById(`key_${paramFields[0]}`).value = "value";
 		document.getElementById(`key_${paramFields[0]}`).style.display = "none";

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -78,17 +78,12 @@ window.generatePaymentUrl = function() {
 				val += "e18";
 			}
 		}
-		console.log('key key', key, key === "uint256", function_name)
 		if (key === "uint256") {
-			console.log('in val', val)
 			if (val !== "") {
 				val += `e${decimals}`;
-				console.log('in valval', val)
 			}
 		}
-		console.log('after', val)
 		if (val !== "") {
-			console.log('if (val !== "") {', val, key, decimals)
 			params[key] = val;
 		}
 	});
@@ -99,8 +94,6 @@ window.generatePaymentUrl = function() {
 	}
     
 	try {
-        console.log('params', params);
-
          const data = {
 			scheme: url_scheme,
 			prefix,
@@ -110,7 +103,6 @@ window.generatePaymentUrl = function() {
 			parameters: params
 		};
         
-        console.log(data);
 		const url = ethParser.build(data);
 		
 		renderUrl(url.replace('ethereum:',`${BASE_URL}/send/`));

--- a/js/index.js
+++ b/js/index.js
@@ -77,14 +77,11 @@ window.generatePaymentUrl = function() {
 				val += "e18";
 			}
 		}
-		console.log('key key', key, key === "uint256", function_name)
 		if (key === "uint256") {
 			if (val !== "") {
 				val += `e${decimals}`;
-				console.log('in valval', val)
 			}
 		}
-		console.log('after', val)
 		if (val !== "") {
 			params[key] = val;
 		}
@@ -96,8 +93,6 @@ window.generatePaymentUrl = function() {
 	}
     
 	try {
-        console.log('params', params);
-
          const data = {
 			scheme: url_scheme,
 			prefix,
@@ -107,7 +102,6 @@ window.generatePaymentUrl = function() {
 			parameters: params
 		};
         
-        console.log(data);
 		const url = ethParser.build(data);
 		
 		renderUrl(url.replace('ethereum:',`${BASE_URL}/send/`));

--- a/js/index.js
+++ b/js/index.js
@@ -63,7 +63,12 @@ window.generatePaymentUrl = function() {
 		document.getElementById("function_name").value !== ""
 			? document.getElementById("function_name").value
 			: null;
+	const decimals =
+		document.getElementById("decimals").value !== ""
+			? document.getElementById("decimals").value
+			: 18;
 	let params = {};
+
 	paramFields.forEach(ts => {
 		const key = document.getElementById(`key_${ts}`).value;
 		let val = document.getElementById(`val_${ts}`).value;
@@ -72,6 +77,14 @@ window.generatePaymentUrl = function() {
 				val += "e18";
 			}
 		}
+		console.log('key key', key, key === "uint256", function_name)
+		if (key === "uint256") {
+			if (val !== "") {
+				val += `e${decimals}`;
+				console.log('in valval', val)
+			}
+		}
+		console.log('after', val)
 		if (val !== "") {
 			params[key] = val;
 		}
@@ -83,6 +96,8 @@ window.generatePaymentUrl = function() {
 	}
     
 	try {
+        console.log('params', params);
+
          const data = {
 			scheme: url_scheme,
 			prefix,
@@ -132,13 +147,13 @@ window.showView = function(name) {
 	} else if(name === 'payment-channel-request'){
 		document.getElementById("payment-channel-request-form").style.display = "block";
 		document.getElementById("reset").style.display = "block";
-
-	}else if (name === "ether") {
+	} else if (name === "ether") {
 		document.getElementById("payment-request").style.display = "none";
 		document.getElementById("payment-request-form").style.display = "block";
 		
 		document.getElementById("function_name").style.display = "none";
 		document.getElementById("add_parameter").style.visibility = "hidden";
+		document.getElementById("decimals").style.display = "none";
 		addNewParam();
 		document.getElementById(`key_${paramFields[0]}`).value = "value";
 		document.getElementById(`key_${paramFields[0]}`).style.display = "none";


### PR DESCRIPTION
Before we weren't following the eip 681 standard on transfer links, instead of generating a link with the token amount (in float) we are now using atomic units https://github.com/ethereum/EIPs/blob/master/EIPS/eip-681.md
The user has to manually put decimals or the default will be 18